### PR TITLE
Use a better name for the first connexion

### DIFF
--- a/wallabag/Storyboard/de.lproj/Registration.strings
+++ b/wallabag/Storyboard/de.lproj/Registration.strings
@@ -26,8 +26,8 @@
 /* Class = "UITextField"; placeholder = "Password"; ObjectID = "UQC-pk-uO1"; */
 "UQC-pk-uO1.placeholder" = "Kennwort";
 
-/* Class = "UIButton"; normalTitle = "Register"; ObjectID = "Zn4-yG-cxW"; */
-"Zn4-yG-cxW.normalTitle" = "Registrieren";
+/* Class = "UIButton"; normalTitle = "Log in"; ObjectID = "Zn4-yG-cxW"; */
+"Zn4-yG-cxW.normalTitle" = "Anmelden";
 
 /* Class = "UITextField"; placeholder = "ClientId"; ObjectID = "dsM-5G-HXR"; */
 "dsM-5G-HXR.placeholder" = "ClientId";

--- a/wallabag/Storyboard/fr.lproj/Registration.strings
+++ b/wallabag/Storyboard/fr.lproj/Registration.strings
@@ -26,8 +26,8 @@
 /* Class = "UITextField"; placeholder = "Password"; ObjectID = "UQC-pk-uO1"; */
 "UQC-pk-uO1.placeholder" = "Mot de passe";
 
-/* Class = "UIButton"; normalTitle = "Register"; ObjectID = "Zn4-yG-cxW"; */
-"Zn4-yG-cxW.normalTitle" = "S'enregistrer";
+/* Class = "UIButton"; normalTitle = "Log in"; ObjectID = "Zn4-yG-cxW"; */
+"Zn4-yG-cxW.normalTitle" = "Se connecter";
 
 /* Class = "UITextField"; placeholder = "ClientId"; ObjectID = "dsM-5G-HXR"; */
 "dsM-5G-HXR.placeholder" = "ClientId";

--- a/wallabag/Storyboard/ro.lproj/Registration.strings
+++ b/wallabag/Storyboard/ro.lproj/Registration.strings
@@ -26,8 +26,8 @@
 /* Class = "UITextField"; placeholder = "Password"; ObjectID = "UQC-pk-uO1"; */
 "UQC-pk-uO1.placeholder" = "Parolă";
 
-/* Class = "UIButton"; normalTitle = "Register"; ObjectID = "Zn4-yG-cxW"; */
-"Zn4-yG-cxW.normalTitle" = "Înregistrare";
+/* Class = "UIButton"; normalTitle = "Log in"; ObjectID = "Zn4-yG-cxW"; */
+"Zn4-yG-cxW.normalTitle" = "A se conecta";
 
 /* Class = "UITextField"; placeholder = "ClientId"; ObjectID = "dsM-5G-HXR"; */
 "dsM-5G-HXR.placeholder" = "ClientId";


### PR DESCRIPTION
Use won't be able to "register" to wallabag but it'll have to "login" to the iOS app.
Using "register" user can understand it'll be able to register to use wallabag server/iOS/firefox/etc.. like creating an account.
Using "login" user might better understand it needs an account first to be able to use the iOS app

I don't know if it's the right way to update a translation BTW 😶 
DE & RO translation come from wordreference, they might no be accurate..