### PR TITLE
Extract title and content when adding an entry via Share extension from Safari

### DIFF
--- a/App/Lib/WallabagSession.swift
+++ b/App/Lib/WallabagSession.swift
@@ -49,7 +49,7 @@ final class WallabagSession: ObservableObject {
     }
 
     func addEntry(url: String) async throws {
-        let wallabagEntry: WallabagEntry = try await kit.send(to: WallabagEntryEndpoint.add(url: url))
+        let wallabagEntry: WallabagEntry = try await kit.send(to: WallabagEntryEndpoint.add(url: url, title: nil, content: nil))
 
         let entry = Entry(context: coreDataContext)
         entry.hydrate(from: wallabagEntry)

--- a/Intents/AddEntryIntent.swift
+++ b/Intents/AddEntryIntent.swift
@@ -15,7 +15,7 @@ struct AddEntryIntent: WallabagIntent {
 
     func perform() async throws -> some IntentResult {
         _ = try await kit.requestTokenAsync()
-        _ = try await kit.send(to: WallabagEntryEndpoint.add(url: url.absoluteString))
+        _ = try await kit.send(to: WallabagEntryEndpoint.add(url: url.absoluteString, title: nil, content: nil))
 
         return .result()
     }

--- a/WallabagKit/Sources/WallabagKit/Endpoint/WallabagEntryEndpoint.swift
+++ b/WallabagKit/Sources/WallabagKit/Endpoint/WallabagEntryEndpoint.swift
@@ -4,7 +4,7 @@ public enum WallabagEntryEndpoint: WallabagKitEndpoint {
     public typealias Object = WallabagEntry
 
     case get(page: Int = 1, perPage: Int = 30)
-    case add(url: String)
+    case add(url: String, title: String?, content: String?)
     case addTag(tag: String, entry: Int)
     case delete(id: Int)
     case deleteTag(tagId: Int, entry: Int)
@@ -54,9 +54,9 @@ public enum WallabagEntryEndpoint: WallabagKitEndpoint {
 
     public func getBody() -> Data {
         switch self {
-        case let .add(url):
+        case let .add(url, title, content):
             // swiftlint:disable:next force_try
-            try! JSONSerialization.data(withJSONObject: ["url": url], options: .prettyPrinted)
+            try! JSONSerialization.data(withJSONObject: ["url": url, "title": title, "content": content], options: .prettyPrinted)
         case let .update(_, parameters):
             // swiftlint:disable:next force_try
             try! JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted)

--- a/bagit/ExtensionClass.js
+++ b/bagit/ExtensionClass.js
@@ -3,7 +3,9 @@ var ExtensionClass = function() {};
 ExtensionClass.prototype = {
     run: function(arguments) {
         arguments.completionFunction({
-            "href": document.location.href
+            "href": document.location.href,
+            "contentHTML": document.body.innerHTML,
+            "title": document.title.toString()
         });
     }
 };


### PR DESCRIPTION
This PR gives the Share extension the option of using the title and content directly from Safari when adding an article.  For me, this makes it much easier to add articles that are behind a paywall.

This feature is also supported by the wallabagger browser extension. 