### PR TITLE
Fix project compilation and tests

### DIFF
--- a/wallabag.xcodeproj/project.pbxproj
+++ b/wallabag.xcodeproj/project.pbxproj
@@ -1125,7 +1125,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G97URPCGB8;
 				INFOPLIST_FILE = wallabagTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1150,7 +1149,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G97URPCGB8;
 				INFOPLIST_FILE = wallabagTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1177,7 +1175,6 @@
 				CURRENT_PROJECT_VERSION = 319;
 				DEVELOPMENT_TEAM = G97URPCGB8;
 				INFOPLIST_FILE = bagit/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1200,7 +1197,6 @@
 				CURRENT_PROJECT_VERSION = 319;
 				DEVELOPMENT_TEAM = G97URPCGB8;
 				INFOPLIST_FILE = bagit/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1352,7 +1348,6 @@
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1382,7 +1377,6 @@
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/wallabagTests/Features/Registration/Server/ServerViewModelTests.swift
+++ b/wallabagTests/Features/Registration/Server/ServerViewModelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class ServerViewModelTests: XCTestCase {
     var cancellable = Set<AnyCancellable>()
 
-    override class func setUp() {
+    override func setUp() {
         WallabagUserDefaults.host = ""
     }
 
@@ -19,45 +19,37 @@ final class ServerViewModelTests: XCTestCase {
     func testInvalidUrl() {
         let model = ServerViewModel()
 
-        let expectation = XCTestExpectation(description: "Invalid url")
-
         XCTAssertEqual("", model.url)
         XCTAssertFalse(model.isValid)
 
-        model.$isValid
-            .dropFirst()
-            .sink(receiveValue: {
-                XCTAssertFalse($0)
-                expectation.fulfill()
-            })
-            .store(in: &cancellable)
-
         model.url = "azerty"
         XCTAssertEqual("", WallabagUserDefaults.host)
-
-        wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(model.isValid)
     }
 
     func testValidUrl() {
         let model = ServerViewModel()
 
-        let expectation = XCTestExpectation(description: "Valid url")
-
         XCTAssertEqual("", model.url)
         XCTAssertEqual("", WallabagUserDefaults.host)
         XCTAssertFalse(model.isValid)
 
-        model.$isValid
-            .dropFirst()
-            .sink(receiveValue: {
-                XCTAssertTrue($0)
-                expectation.fulfill()
-            })
-            .store(in: &cancellable)
         model.url = "https://wallabag.it"
 
-        XCTAssertEqual("https://wallabag.it", WallabagUserDefaults.host)
+        XCTAssertEqual("", WallabagUserDefaults.host)
+        XCTAssertTrue(model.isValid)
+    }
 
-        wait(for: [expectation], timeout: 1)
+    func testUpdateHostOnGoNext() {
+        let model = ServerViewModel()
+
+        XCTAssertEqual("", model.url)
+        XCTAssertEqual("", WallabagUserDefaults.host)
+        XCTAssertFalse(model.isValid)
+        model.url = "https://wallabag.it"
+        XCTAssertEqual("", WallabagUserDefaults.host)
+
+        model.goNext()
+        XCTAssertEqual("https://wallabag.it", WallabagUserDefaults.host)
     }
 }


### PR DESCRIPTION
## Rationale

Upon cloning, I tried to compile the project and run the tests and unfortunately there were two issues:
1. the deployment target of the test target (iOS 16) did not match the deployment target of the App target
2. `ServerViewModelTests` had compilation issues because the file was not updated with the changes introduce in #409 

## Changes

- Use the project's "deployment target" setting in all targets so that only one place needs to be changed if the "deployment target" needs to be updated.
- Fix `ServerViewModelTests`:
  - `.isValid` property is not a `@Published` anymore
  - changing the `.url` property does not apply it to `UserDefaults` instantly
  - add a test to check the impact of `goNext()` to `UserDefaults`
  - replace `class func setUp()` with `func setUp()` because the reset of `WallabagUserDefaults.host` must be done for each test. the `class` one is only run once for the whole `XCTestCase` whereas the other one is run before each test.
