### PR TITLE
Improve dark mode link color for readability

### DIFF
--- a/App/html-ressources/main.css
+++ b/App/html-ressources/main.css
@@ -141,7 +141,7 @@ blockquote {
   }
 
   a {
-      color: #137fb3;
+      color: #6CA0DC;
   }
 
   blockquote {


### PR DESCRIPTION
This small change updates the link color in 'main.css' for users viewing an article in dark mode. The default blue (#137fb3) was too saturated against the black background. Updated to #6CA0DC for a softer, more readable tone while preserving contrast and accessibility.