### PR TITLE
Fix for issue #339: iOS app not syncing when articles are deleted from the web UI

### DIFF
--- a/App/Features/Sync/AppSync.swift
+++ b/App/Features/Sync/AppSync.swift
@@ -100,6 +100,15 @@ extension AppSync {
 
                 backgroundContext.delete(entryToDelete)
             }
+            // Ensure deletions are saved and changes are merged
+            try backgroundContext.save()
+            coreData.persistentContainer.viewContext.perform {
+                do {
+                    try self.coreData.persistentContainer.viewContext.save()
+                } catch {
+                    logger.error("Error saving main context after purge: \(error.localizedDescription)")
+                }
+            }
         } catch {
             logger.error("Error in batch delete")
         }


### PR DESCRIPTION
This fix was created with help from GitHub Copilot and GPT-4.1

The bug is caused by the sync logic not removing locally cached articles that have been deleted on the server (via the web UI). The root cause is the following:

- The iOS app fetches all articles from the server and updates or inserts them locally.
- It keeps track of the IDs of all articles received from the server in entriesSynced.
- After syncing, it calls purge(), which deletes any local articles whose IDs are not in entriesSynced.
- However, this purge is done in a background context and may not be saved or merged properly with the main context, or the UI may not be updated to reflect these deletions.

The fix implements the following logic:

- After purging deleted articles from the local database, changes are now saved and merged into the main context to ensure the UI updates and deleted articles are removed from the iOS app after a sync.

Link to bug report: https://github.com/wallabag/ios-app/issues/339