### PR TITLE
Fix for issue 339

### DIFF
--- a/App/Features/Sync/AppSync.swift
+++ b/App/Features/Sync/AppSync.swift
@@ -86,10 +86,6 @@ extension AppSync {
     }
 
     private func purge() {
-        if entriesSynced.count == 0 {
-            return
-        }
-
         let fetchRequest = Entry.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "NOT (id IN %@)", argumentArray: [entriesSynced])
 
@@ -100,15 +96,7 @@ extension AppSync {
 
                 backgroundContext.delete(entryToDelete)
             }
-            // Ensure deletions are saved and changes are merged
             try backgroundContext.save()
-            coreData.persistentContainer.viewContext.perform {
-                do {
-                    try self.coreData.persistentContainer.viewContext.save()
-                } catch {
-                    logger.error("Error saving main context after purge: \(error.localizedDescription)")
-                }
-            }
         } catch {
             logger.error("Error in batch delete")
         }

--- a/App/Features/Sync/AppSync.swift
+++ b/App/Features/Sync/AppSync.swift
@@ -100,6 +100,15 @@ extension AppSync {
 
                 backgroundContext.delete(entryToDelete)
             }
+            // Ensure deletions are saved and changes are merged
+            try backgroundContext.save()
+            coreData.persistentContainer.viewContext.perform {
+                do {
+                    try self.coreData.persistentContainer.viewContext.save()
+                } catch {
+                    logger.error("Error saving main context after purge: \(error.localizedDescription)")
+                }
+            }
         } catch {
             logger.error("Error in batch delete")
         }


### PR DESCRIPTION
The previous fix I submitted does not solve this issue, hence submitting this one, which was more thoroughly tested. It turns out that the bug is actually an edge case: articles are not synced only when the list of articles becomes empty on the ser
ver. This is because `purge()` has a guard testing for `entriesSynced.count == 0` which prevents the sync from happening in the iOS app. This commit removes the guard, enabling the correct syncing behavior.