### PR TITLE
Fix #457 - Persist entry sorting preferences across app launches

### DIFF
--- a/App/Features/Entry/EntriesView.swift
+++ b/App/Features/Entry/EntriesView.swift
@@ -8,9 +8,9 @@ struct EntriesView: View {
     @Environment(WallabagPlusStore.self) private var wallabagPlusStore
     @EnvironmentObject var appState: AppState
     @StateObject var searchViewModel = SearchViewModel()
-    @State var entriesSortedById = true
-    @State var entriesSortedByReadingTime = false
-    @State var entriesSortedByAscending = false
+    @AppStorage("entriesSortedById") var entriesSortedById = true
+    @AppStorage("entriesSortedByReadingTime") var entriesSortedByReadingTime = false
+    @AppStorage("entriesSortedByAscending") var entriesSortedByAscending = false
     @State private var showPaywallWallabagPlus = false
 
     var body: some View {
@@ -26,8 +26,15 @@ struct EntriesView: View {
                 entriesSortedByAscending: entriesSortedByAscending
             )
         }
-        .onChange(of: entriesSortedByReadingTime) { _, _ in
-            entriesSortedById = false
+        .onChange(of: entriesSortedById) { _, newValue in
+            if newValue {
+                entriesSortedByReadingTime = false
+            }
+        }
+        .onChange(of: entriesSortedByReadingTime) { _, newValue in
+            if newValue {
+                entriesSortedById = false
+            }
         }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {

--- a/wallabag.xcodeproj/project.pbxproj
+++ b/wallabag.xcodeproj/project.pbxproj
@@ -1495,7 +1495,7 @@
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios-spm.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.15.0;
+				minimumVersion = 5.16.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Changed sorting state from @State to @AppStorage in EntriesView to ensure user preferences are saved to UserDefaults. Also made sorting criteria mutually exclusive for a better UX.

Also upgraded RevenueCat to fix a build issue.